### PR TITLE
Auto-detect twist reference joints

### DIFF
--- a/RigToolUI.py
+++ b/RigToolUI.py
@@ -147,7 +147,7 @@ TOOL_CATEGORIES = [
         [
             {
                 "label": u"Create Twist Chain",
-                "tooltip": u"開始ジョイントと参照ジョイントを順に選択してツイスト用補助ジョイントを作成します。",
+                "tooltip": u"開始ジョイントを選択すると子から参照ジョイントを自動検出してツイスト用補助ジョイントを作成します。",
                 "callback": _create_twist_chain_with_count_dialog,
             },
             {


### PR DESCRIPTION
## Summary
- automatically determine the twist reference joint from the selected joint's children and skip when conditions are not met
- mirror twist chains using the same base joint detection logic instead of connection graph traversal
- refresh the UI tooltip to explain the new automatic reference workflow

## Testing
- python -m compileall CreateTwistChain.py MirrorTwistHalfJoint.py RigToolUI.py

------
https://chatgpt.com/codex/tasks/task_e_68dbad7a8400832fa191cfcd1c6825fe