### PR TITLE
Add skin bind helper that skips half joints

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ ARig Tool は Autodesk Maya 上でのキャラクターリギング作業を効�
 - **Mirror Twist & Half Joint** — `_L` / `_R` の命名規則に従ってツイストチェーンや半回転ジョイント、サポートジョイントを反対側に複製し、必要に応じてドリブンキーも反転コピーします。【F:RigToolUI.py†L149-L202】【F:MirrorTwistHalfJoint.py†L1-L267】
 - **Driven Key Helper** — Twist / Half / Support ジョイントの駆動設定を想定した UI を提供し、ドライバー軸と対象属性を選んでドリブンキーを一括設定できます。【F:RigToolUI.py†L149-L202】【F:DrivenKeyTool.py†L32-L200】
 - **Driven Key Matrix** — 選択ジョイントに設定されたドリブンキーを行列形式で表示し、入力値・出力値をダブルクリックで編集できる管理ツールです。【F:RigToolUI.py†L149-L202】【F:DrivenKeyMatrixTool.py†L1-L200】
+- **Bind Skin (Skip Half)** — Half ジョイントを除外しつつ `_Half_INF` ジョイントは含めてジョイント階層を自動収集し、選択ジオメトリへスキンバインドします。【F:RigToolUI.py†L149-L202】【F:SkinBindTool.py†L1-L111】
 - **Simple Rig From Ctrl + Joints** — コントローラーとジョイントを選択すると、各ジョイントにゼログループ付きの複製コントローラーを配置し、親子関係とコンストレイントを自動構築します。【F:RigToolUI.py†L149-L202】【F:csimplerig.py†L16-L48】
 - **Create Eyelid Rig** — ベースコントローラーとまぶたジョイントを元に Aim / Parent Constraint を含むまぶたリグをセットアップし、複製コントローラーを選択状態にします。【F:RigToolUI.py†L149-L202】【F:ArigUtil.py†L83-L139】
 - **Create Stretchy Spline IK** — 開始ジョイントと終了ジョイントを指定してスプライン IK ハンドルとカーブを作成し、カーブ長に応じたストレッチとクラスタを自動付与します。【F:RigToolUI.py†L149-L202】【F:ArigUtil.py†L209-L253】

--- a/RigToolUI.py
+++ b/RigToolUI.py
@@ -201,6 +201,11 @@ TOOL_CATEGORIES = [
                 "callback": partial(_run_with_warning, _open_check_motion_tool),
             },
             {
+                "label": u"Bind Skin (Skip Half)",
+                "tooltip": u"選択したジョイント階層からHalfジョイントを除外し、Half_INFジョイントを含めてバインドします。",
+                "callback": partial(_call_module_function, "SkinBindTool", "bind_skin_excluding_half"),
+            },
+            {
                 "label": u"Simple Rig From Ctrl + Joints",
                 "tooltip": u"コントローラーを1つ、続いてジョイントを選択し、複製コントローラーとゼログループを自動配置します。",
                 "callback": partial(_call_module_function, "csimplerig", "simple_rig_from_ctrl_and_joints"),

--- a/SkinBindTool.py
+++ b/SkinBindTool.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""Utilities for skin binding operations used from the ARig tool UI."""
+
+import maya.cmds as cmds
+
+
+def _short_name(node):
+    return node.split("|")[-1]
+
+
+def _is_bind_geometry(node):
+    """Return True if the node can be used as a bind target geometry."""
+
+    if not cmds.objExists(node):
+        return False
+
+    node_type = cmds.nodeType(node)
+    if node_type in {"mesh", "nurbsSurface", "lattice"}:
+        return True
+
+    if node_type != "transform":
+        return False
+
+    shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+    for shape in shapes:
+        if cmds.nodeType(shape) in {"mesh", "nurbsSurface", "lattice"}:
+            return True
+    return False
+
+
+def _collect_bind_joints(root):
+    """Collect joints under the root excluding Half joints except Half_INF."""
+
+    joints = []
+
+    full_root = cmds.ls(root, long=True) or []
+    if not full_root:
+        return joints
+
+    root_path = full_root[0]
+
+    descendants = cmds.listRelatives(root_path, allDescendents=True, type="joint", fullPath=True) or []
+    descendants = list(reversed(descendants))
+
+    for joint in [root_path] + descendants:
+        short = _short_name(joint)
+        if "Half" in short and "Half_INF" not in short:
+            continue
+        joints.append(joint)
+
+    # Remove duplicates while keeping order.
+    unique = []
+    seen = set()
+    for joint in joints:
+        if joint in seen:
+            continue
+        seen.add(joint)
+        unique.append(joint)
+    return unique
+
+
+def bind_skin_excluding_half():
+    """Bind the selected geometry to the joint hierarchy without Half joints."""
+
+    selection = cmds.ls(sl=True, long=True) or []
+    if not selection:
+        cmds.warning(u"ジョイントのルートとバインド対象ジオメトリを選択してください。")
+        return
+
+    joint_roots = [node for node in selection if cmds.nodeType(node) == "joint"]
+    if not joint_roots:
+        cmds.warning(u"ジョイントのルートを少なくとも1つ選択してください。")
+        return
+
+    geometries = [node for node in selection if _is_bind_geometry(node)]
+    if not geometries:
+        cmds.warning(u"バインド対象のジオメトリを選択してください。")
+        return
+
+    bind_joints = []
+    for root in joint_roots:
+        bind_joints.extend(_collect_bind_joints(root))
+
+    # Remove duplicates while keeping order.
+    unique_joints = []
+    seen = set()
+    for joint in bind_joints:
+        if joint in seen:
+            continue
+        seen.add(joint)
+        unique_joints.append(joint)
+
+    if not unique_joints:
+        cmds.warning(u"バインドに使用できるジョイントが見つかりませんでした。")
+        return
+
+    original_selection = cmds.ls(sl=True, long=True) or []
+    cmds.undoInfo(openChunk=True)
+    try:
+        for geometry in geometries:
+            try:
+                cmds.skinCluster(unique_joints, geometry, toSelectedBones=True)
+            except RuntimeError as exc:
+                cmds.warning(u"{0} のスキンバインドに失敗しました: {1}".format(_short_name(geometry), exc))
+    finally:
+        cmds.undoInfo(closeChunk=True)
+        if original_selection:
+            cmds.select(original_selection, replace=True)
+        else:
+            cmds.select(clear=True)
+


### PR DESCRIPTION
## Summary
- add a skin bind helper that gathers joint hierarchies while skipping Half joints and keeping Half_INF joints for binding
- expose the helper from the launcher UI and document the new tool in the README

## Testing
- not run (Maya environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de1fedb33c832f9aede8c900ab425b