### PR TITLE
Fix twist dialog lifecycle and improve reverse twist detection

### DIFF
--- a/MirrorTwistHalfJoint.py
+++ b/MirrorTwistHalfJoint.py
@@ -119,8 +119,10 @@ def _find_reverse_twist_root(start):
     target_short = f"{base_short}_twistRoot"
 
     if parent:
-        siblings = cmds.listRelatives(parent, c=True, type="joint", f=True) or []
+        siblings = cmds.listRelatives(parent, c=True, f=True) or []
         for sibling in siblings:
+            if sibling == start:
+                continue
             if sibling.split("|")[-1] == target_short:
                 return sibling
 

--- a/RigToolUI.py
+++ b/RigToolUI.py
@@ -65,7 +65,9 @@ def _open_check_motion_tool():
 
 
 class TwistChainDialog(QtWidgets.QDialog):
-    def __init__(self, parent=maya_main_window()):
+    def __init__(self, parent=None):
+        if parent is None:
+            parent = maya_main_window()
         super(TwistChainDialog, self).__init__(parent)
         self.setObjectName("twistChainDialog")
         self.setWindowTitle(u"Create Twist Chain")


### PR DESCRIPTION
## Summary
- avoid holding on to a stale Maya main window wrapper by resolving the parent during TwistChainDialog initialisation
- expand reverse twist root lookup to prefer siblings in the same hierarchy level when mirroring twist chains

## Testing
- not run (Maya environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de3ad8f8c8832fb648bbae20af39f5