### PR TITLE
Add UI option to skip X rotation when creating half joints

### DIFF
--- a/CreateTwistChain.py
+++ b/CreateTwistChain.py
@@ -28,11 +28,23 @@ def _is_half_joint(joint):
     )
 
 
+def _is_half_support_joint(joint):
+    short_name = joint.split("|")[-1]
+    lowered = short_name.lower()
+    if "_sup" not in lowered:
+        return False
+    if lowered.startswith("halfsup") or lowered.startswith("half_sup"):
+        return True
+    return "_half" in lowered
+
+
 def _list_base_children(joint):
     children = cmds.listRelatives(joint, c=True, type="joint") or []
     bases = []
     for child in children:
         if _is_half_joint(child):
+            continue
+        if _is_half_support_joint(child):
             continue
         if cmds.attributeQuery("twistWeight", node=child, exists=True):
             continue

--- a/MirrorTwistHalfJoint.py
+++ b/MirrorTwistHalfJoint.py
@@ -160,11 +160,23 @@ def _is_half_joint(joint):
     )
 
 
+def _is_half_support_joint(joint):
+    short_name = joint.split("|")[-1]
+    lowered = short_name.lower()
+    if "_sup" not in lowered:
+        return False
+    if lowered.startswith("halfsup") or lowered.startswith("half_sup"):
+        return True
+    return "_half" in lowered
+
+
 def _list_base_children(joint):
     children = cmds.listRelatives(joint, c=True, type="joint") or []
     bases = []
     for child in children:
         if _is_half_joint(child):
+            continue
+        if _is_half_support_joint(child):
             continue
         if cmds.attributeQuery("twistWeight", node=child, exists=True):
             continue

--- a/RigToolUI.py
+++ b/RigToolUI.py
@@ -178,7 +178,7 @@ TOOL_CATEGORIES = [
             {
                 "label": u"Create Half Rotation Joint",
                 "tooltip": u"選択したジョイントに半回転ジョイントとINFジョイントを生成し、回転を0.5倍に接続します。",
-                "callback": partial(_call_module_function, "CreateHalfRotJoint", "create_half_rotation_joint"),
+                "callback": partial(_call_module_function, "CreateHalfRotJoint", "show_half_rotation_dialog"),
             },
             {
                 "label": u"Create Support Joint",


### PR DESCRIPTION
## Summary
- add a dialog and preference to control whether half rotation joints connect X rotation
- honor the skip-X option when wiring half joints and persist the user choice
- ignore half support joints while detecting twist chain bases to avoid false positives

## Testing
- python -m compileall CreateHalfRotJoint.py CreateTwistChain.py MirrorTwistHalfJoint.py RigToolUI.py

------
https://chatgpt.com/codex/tasks/task_e_68de3e636390832f85f2811fa7a1542f