### PR TITLE
Handle _D suffix when generating derived joints

### DIFF
--- a/CreateHalfRotJoint.py
+++ b/CreateHalfRotJoint.py
@@ -13,6 +13,12 @@ OPTIONVAR_SKIP_ROTATE_X = "ARigTool_SkipHalfRotateX"
 _half_rotation_dialog = None
 
 
+def _strip_duplicate_suffix(name):
+    if name.endswith("_D"):
+        return name[:-2]
+    return name
+
+
 def _uniquify(base):
     if not cmds.objExists(base):
         return base
@@ -64,7 +70,7 @@ def create_half_rotation_joint(skip_rotate_x=None):
     created = []
     try:
         for j in sel:
-            base = j.split("|")[-1]
+            base = _strip_duplicate_suffix(j.split("|")[-1])
 
             half_name = _uniquify(base + "_Half")
             half = cmds.duplicate(j, po=True, n=half_name)[0]

--- a/CreateSupportJoint.py
+++ b/CreateSupportJoint.py
@@ -40,6 +40,8 @@ def create_support_joint():
 
     source_joint = selection[0]
     short = _short_name(source_joint)
+    if short.endswith("_D"):
+        short = short[:-2]
     new_name = _unique_name(f"{short}_Sup")
 
     cmds.undoInfo(openChunk=True)


### PR DESCRIPTION
## Summary
- strip trailing _D from selected joint names before generating support joints
- reuse the suffix-free base name when creating half rotation joints and their helper nodes

## Testing
- not run (Maya environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68de422c8430832f92cec976f02e4ff9