### PR TITLE
Improve twist root detection for twist chain tools

### DIFF
--- a/CreateTwistChain.py
+++ b/CreateTwistChain.py
@@ -41,6 +41,12 @@ def _list_base_children(joint):
             continue
         if _is_support_joint(child):
             continue
+        short_name = child.split("|")[-1]
+        lowered = short_name.lower()
+        if "twistroot" in lowered:
+            continue
+        if "twist" in lowered:
+            continue
         if cmds.attributeQuery("twistWeight", node=child, exists=True):
             continue
         bases.append(child)
@@ -463,6 +469,29 @@ def _find_reverse_twist_root(base_joint):
     if base_short.endswith("_D"):
         base_short = base_short[:-2]
     candidate_short = base_short + "_twistRoot"
+    # Prefer siblings that contain "twistRoot" in their name and share the same parent
+    parent = cmds.listRelatives(base_joint, p=True, pa=True) or []
+    if parent:
+        siblings = cmds.listRelatives(parent[0], c=True, type="joint", pa=True) or []
+    else:
+        siblings = cmds.ls("|*", type="joint", long=True) or []
+
+    base_long = cmds.ls(base_joint, long=True) or [base_joint]
+    base_long = base_long[0]
+
+    for sibling in siblings:
+        if not sibling or sibling == base_long:
+            continue
+        short_name = sibling.split("|")[-1]
+        if short_name == candidate_short:
+            return sibling
+
+    for sibling in siblings:
+        if not sibling or sibling == base_long:
+            continue
+        if "twistroot" in sibling.split("|")[-1].lower():
+            return sibling
+
     return _find_joint_by_short_name(base_joint, candidate_short)
 
 

--- a/MirrorTwistHalfJoint.py
+++ b/MirrorTwistHalfJoint.py
@@ -133,6 +133,28 @@ def _find_reverse_twist_root(start):
         return None
 
     target_short = f"{base_short}_twistRoot"
+    parent = cmds.listRelatives(start, p=True, pa=True) or []
+    if parent:
+        siblings = cmds.listRelatives(parent[0], c=True, type="joint", pa=True) or []
+    else:
+        siblings = cmds.ls("|*", type="joint", long=True) or []
+
+    start_long = cmds.ls(start, long=True) or [start]
+    start_long = start_long[0]
+
+    for sibling in siblings:
+        if not sibling or sibling == start_long:
+            continue
+        short = sibling.split("|")[-1]
+        if short == target_short:
+            return sibling
+
+    for sibling in siblings:
+        if not sibling or sibling == start_long:
+            continue
+        if "twistroot" in sibling.split("|")[-1].lower():
+            return sibling
+
     return _find_joint_by_short_name(start, target_short)
 
 
@@ -183,6 +205,12 @@ def _list_base_children(joint):
         if _is_half_joint(child):
             continue
         if _is_half_support_joint(child):
+            continue
+        short_name = child.split("|")[-1]
+        lowered = short_name.lower()
+        if "twistroot" in lowered:
+            continue
+        if "twist" in lowered:
             continue
         if cmds.attributeQuery("twistWeight", node=child, exists=True):
             continue


### PR DESCRIPTION
## Summary
- ignore child joints named with twistRoot when collecting base candidates and treat other twist-named children as non-bases
- detect existing reverse twist roots by scanning siblings that contain the twistRoot tag before falling back to a global lookup
- apply the same sibling-based twist root detection logic to the mirror utility

## Testing
- python -m compileall CreateTwistChain.py MirrorTwistHalfJoint.py

------
https://chatgpt.com/codex/tasks/task_e_68de81a4677c832f88ee2c41a27e0dba