### PR TITLE
Support negative twist axis selection

### DIFF
--- a/RigToolUI.py
+++ b/RigToolUI.py
@@ -92,7 +92,7 @@ class TwistChainDialog(QtWidgets.QDialog):
 
         self.axis_label = QtWidgets.QLabel(u"ツイスト軸:")
         self.axis_combo = QtWidgets.QComboBox()
-        self.axis_combo.addItems(["X", "Y", "Z"])
+        self.axis_combo.addItems(["X", "Y", "Z", "-X", "-Y", "-Z"])
         self.axis_combo.setToolTip(
             u"生成されるツイストジョイントの回転軸を選択します。"
         )


### PR DESCRIPTION
## Summary
- allow the twist-axis selection to include negative directions when creating a twist chain
- insert multiplier nodes so negative axes flip the driven rotation and expose the sign in detection
- update the twist chain editor to preserve, display, and rebuild chains with signed axes

## Testing
- python -m compileall CreateTwistChain.py RigToolUI.py

------
https://chatgpt.com/codex/tasks/task_e_68e356e5fe80832f9d6eba27083ecbdc