### PR TITLE
Handle axisAngleToQuat attribute naming differences

### DIFF
--- a/CreateTwistChain.py
+++ b/CreateTwistChain.py
@@ -276,9 +276,22 @@ def _create_standard_twist_chain(
             )
 
         axis_angle = cmds.createNode("axisAngleToQuat", n=f"{base_tag}_twistBend_AATQ")
+
+        axis_prefix = ".axis"
+        if not cmds.attributeQuery("axisX", node=axis_angle, exists=True):
+            axis_prefix = ".inputAxis"
+
+        angle_attr = ".angle"
+        if not cmds.attributeQuery("angle", node=axis_angle, exists=True):
+            angle_attr = ".inputAngle"
+
         for ax in _AXES:
-            cmds.connectAttr(angle_between + ".axis" + ax, axis_angle + ".axis" + ax, f=True)
-        cmds.connectAttr(angle_between + ".angle", axis_angle + ".angle", f=True)
+            cmds.connectAttr(
+                angle_between + ".axis" + ax,
+                axis_angle + axis_prefix + ax,
+                f=True,
+            )
+        cmds.connectAttr(angle_between + ".angle", axis_angle + angle_attr, f=True)
 
         quat_invert_bend = cmds.createNode("quatInvert", n=f"{base_tag}_twistBend_INV")
         _connect_quaternion(axis_angle + ".outputQuat", quat_invert_bend + ".inputQuat")


### PR DESCRIPTION
## Summary
- ensure axisAngleToQuat connections work whether attributes are named axisX/angle or inputAxisX/inputAngle
- prevent twist creation from failing when Maya uses alternate attribute names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eba12e2564832fb90235b6f0efe494