### PR TITLE
Use primary child joint for matrix twist rotation

### DIFF
--- a/CreateTwistChain.py
+++ b/CreateTwistChain.py
@@ -263,9 +263,14 @@ def _create_standard_twist_chain(
             cmds.setAttr(compose_axis + ".inputTranslate" + axis_name, value)
 
         compose_rot = cmds.createNode("composeMatrix", n=f"{base_tag}_twistRotate_CM")
+        twist_target = ref if cmds.objExists(ref) else start
         for ax in _AXES:
             try:
-                cmds.connectAttr(start + ".rotate" + ax, compose_rot + ".inputRotate" + ax, f=True)
+                cmds.connectAttr(
+                    twist_target + ".rotate" + ax,
+                    compose_rot + ".inputRotate" + ax,
+                    f=True,
+                )
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- ensure the matrix-based twist setup drives Twist_twistRotate_CM from the detected primary child joint
- fall back to the selected joint if the primary child joint cannot be found

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebab6c30ac832f99109042a7618aa6